### PR TITLE
Added gomake build system

### DIFF
--- a/Gomake.sublime-build.sample
+++ b/Gomake.sublime-build.sample
@@ -1,6 +1,0 @@
-{
-	"cmd": "gomake",
-	"path": "/path/to/go/bin:$PATH",
-	"file_regex": "^(.+):([0-9]+):.*",
-	"selector": "source.go"
-}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please see USAGE.md for general usage and other tips for effective usage of GoSu
 Settings
 --------
 
-You can customize the behaviour of GoSublime by creating a settings file in your `User` package. This can be accessed from within SublimeText by going to the menu `Preferences > Browse Packages...`. Create a file named `GoSublime.sublime-settings`. A sample settings file `GoSublime/examples/GoSublime.sublime-settings.example` is provided inside the GoSublime package directory.
+You can customize the behaviour of GoSublime by creating a settings file in your `User` package. This can be accessed from within SublimeText by going to the menu `Preferences > Browse Packages...`. Create a file named `GoSublime.sublime-settings`. A sample settings file `Packages/GoSublime/examples/GoSublime.sublime-settings.example` is provided inside the GoSublime package directory.
 
 Note: Filenames are case-sensitive on some platforms(e.g. Linux) so the filename should be exactly `GoSublime.sublime-settings` with capitalization preserved.
 
@@ -48,11 +48,6 @@ The available settings are:
 * gofmt_cmd - the command that shall be called for gofmt, this can be the command name e.g. `gofmt` or full path to a binary e.g. `/go/bin/gofmt` - default `gofmt`
 
 * run_gofmt_on_save - whether or not to run `gofmt` when the current file is saved - default `false`
-
-Build System
-------------
-
-If you want to use the gomake build system you will have to rename the file Gomake.sublime-build.sample to Gomake.sublime-build. You will have to edit the path value in the file to point to your gomake path. If gomake is in a system path you may also remove the path line completely.
 
 Completion Markers
 ------------------

--- a/USAGE.md
+++ b/USAGE.md
@@ -54,3 +54,14 @@ You may achieve this by adding this to your `Packages/User/Default.sublime-keyma
     }
 
 A sample file is provided in `Packages/GoSublime/examples/Default.sublime-keymap.example`, you can simply copy or symlink it to your `Packages/User` directory.
+
+Build System
+------------
+
+The gomake build system enables Sublime Text 2 to recognize the 5g/6g/8g output so you can jump to compile errors by clicking on the output or cycle through them by using F4/Shift+F4.
+
+If you want to use the gomake build system you will have to copy the file `Packages/GoSublime/examples/Gomake.sublime-build.example` to `Packages/GoSublime/Gomake.sublime-build`.
+
+If gomake is not in your system path you will have to add the following key/value pair to `Packages/GoSublime/Gomake.sublime-build`:
+
+"path": "/path/to/go/bin:$PATH",

--- a/examples/Gomake.sublime-build.example
+++ b/examples/Gomake.sublime-build.example
@@ -1,0 +1,9 @@
+{
+	"cmd": "gomake",
+	"file_regex": "^(.+):([0-9]+):.*",
+	"selector": "source.go",
+	"windows":
+    {
+        "cmd": ["sh", "-c", "gomake"]
+    }
+}


### PR DESCRIPTION
Documentation is in the README.md file under the heading "Build System".

The build system enables a user to jump to errors from 5g/6g/8g by clicking on the output lines or using f4/shift+f4.
