### PR TITLE
Small fix for the dot completion key binding example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -36,21 +36,21 @@ You may achieve this by adding this to your `Packages/User/Default.sublime-keyma
         "command": "run_macro_file",
         "args":
         {
-            "file": "Packages/GoSublime/macros/Dot.sublime-macro",
-            "context":
-            [
-                {
-                    "key": "auto_complete_visible",
-                    "operator": "equal",
-                    "operand": false
-                },
-                {
-                    "key": "selector",
-                    "operator": "equal",
-                    "operand": "source.go"
-                }
-            ]
-        }
+            "file": "Packages/GoSublime/macros/Dot.sublime-macro"
+        },
+        "context":
+        [
+            {
+                "key": "auto_complete_visible",
+                "operator": "equal",
+                "operand": false
+            },
+            {
+                "key": "selector",
+                "operator": "equal",
+                "operand": "source.go"
+            }
+        ]
     }
 
 A sample file is provided in `Packages/GoSublime/examples/Default.sublime-keymap.example`, you can simply copy or symlink it to your `Packages/User` directory.

--- a/examples/Default.sublime-keymap.example
+++ b/examples/Default.sublime-keymap.example
@@ -27,20 +27,20 @@
         "command": "run_macro_file",
         "args":
         {
-            "file": "Packages/GoSublime/macros/Dot.sublime-macro",
-            "context":
-            [
-                {
-                    "key": "auto_complete_visible",
-                    "operator": "equal",
-                    "operand": false
-                },
-                {
-                    "key": "selector",
-                    "operator": "equal",
-                    "operand": "source.go"
-                }
-            ]
-        }
+            "file": "Packages/GoSublime/macros/Dot.sublime-macro"
+        },
+        "context":
+        [
+            {
+                "key": "auto_complete_visible",
+                "operator": "equal",
+                "operand": false
+            },
+            {
+                "key": "selector",
+                "operator": "equal",
+                "operand": "source.go"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The nesting of the context field was wrong, so it was accidently
passed as command argument instead as acting as a filter. Users
who have copied the example configuration were probably unable
to write dots in other languages.
