### PR TITLE
Fix OSX keymap

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,6 @@
+[
+    { "keys": ["super+s"], "command": "gs_fmt_save", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }]},
+    { "keys": ["super+shift+s"], "command": "gs_fmt_prompt_save_as", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
+    { "keys": ["super+shift+g"], "command": "gs_palette", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
+    { "keys": ["ctrl+space"], "command": "auto_complete", "args": {"disable_auto_insert": true, "api_completions_only": true, "next_completion_if_showing": false}, "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] }
+]


### PR DESCRIPTION
This adds an OSX-specific keymap, since by default people save with super+s on OSX.
