### PR TITLE
Update Default (OSX).sublime-keymap

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -97,7 +97,7 @@
 		"command": "gs_browse_packages"
 	},
 	{
-		"keys": ["supe+.", "supe+m"],
+		"keys": ["super+.", "super+m"],
 		"command": "gs_browse_files"
 	},
 	{


### PR DESCRIPTION
Fixed keyboard shortcut for "Browser Files" command.
