### PR TITLE
fix OSX keybindings (super+space doesn't work)

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -34,7 +34,7 @@
 		"context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }]
 	},
 	{
-		"keys": ["super+space"],
+		"keys": ["shift+space"],
 		"command": "auto_complete",
 		"args": {"disable_auto_insert": true, "api_completions_only": true, "next_completion_if_showing": false},
 		"context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }]
@@ -135,7 +135,7 @@
 		"context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }]
 	},
 	{
-		"keys": ["super+.", "super+space"],
+		"keys": ["super+.", "shift+space"],
 		"command": "gs_show_call_tip",
 		"context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }]
 	},
@@ -144,7 +144,7 @@
 		"command": "gs9o_open"
 	},
 	{
-		"keys": ["super+space"],
+		"keys": ["shift+space"],
 		"command": "auto_complete",
 		"args": {"disable_auto_insert": true, "api_completions_only": true, "next_completion_if_showing": false},
 		"context": [{ "key": "selector", "operator": "equal", "operand": "text.9o" }]


### PR DESCRIPTION
`command` + `space` is a global keybinding in OSX to trigger Spotlight.

I chose `shift` instead of `ctrl` or `alt` as the modifier key because those are popular shortcuts for the Alfred app (http://support.alfredapp.com/kb:cmd-space)
