### PR TITLE
Fixes #114 - Integrate GoRename command

### DIFF
--- a/GoSublime.sublime-commands
+++ b/GoSublime.sublime-commands
@@ -66,6 +66,10 @@
 		"command": "gs_fmt"
 	},
 	{
+		"caption": "GoSublime: Rename the current selection (gorename)",
+		"command": "gs_gorename"
+	},
+	{
 		"caption": "GoSublime: New Go File",
 		"command": "gs_new_go_file"
 	},

--- a/gscommands.py
+++ b/gscommands.py
@@ -211,7 +211,7 @@ class GsGorenameCommand(sublime_plugin.TextCommand):
 		else:
 			scope_ok = gs.is_go_source_view(self.view)
 
-		return scope_ok and gs.setting('fmt_enabled') is True
+		return scope_ok 
 
 	def run(self, edit):
 		view = self.view

--- a/gscommands.py
+++ b/gscommands.py
@@ -2,6 +2,7 @@ from gosubl import gs
 from gosubl import gspatch
 from gosubl import mg9
 import datetime
+import subprocess
 import os
 import sublime
 import sublime_plugin
@@ -201,3 +202,61 @@ class GsPatchImportsCommand(sublime_plugin.TextCommand):
 				gs.set_attr(k, added_path)
 			else:
 				gs.del_attr(k)
+
+class GsGorenameCommand(sublime_plugin.TextCommand):
+	def is_enabled(self):
+		fn = self.view.file_name()
+		if fn:
+			scope_ok = fn.lower().endswith('.go')
+		else:
+			scope_ok = gs.is_go_source_view(self.view)
+
+		return scope_ok and gs.setting('fmt_enabled') is True
+
+	def run(self, edit):
+		view = self.view
+
+		# if view.is_dirty():
+		# 	sublime.error_message("{0}: GoRename failure: Unsaved file".format(DOMAIN))
+		# 	return 
+
+		region = view.sel()[0]
+
+		# If the current selection is empty, try to expand
+		# it to the word under the cursor
+		if region.empty():
+			region = view.word(region)
+
+		if region.empty(): 
+			sublime.message_dialog('Select an identifier you would like to rename and try again.')
+			return
+
+		current_selection = view.substr(region)
+		filename = view.file_name()
+		
+		def on_done(new_name):
+			if new_name == current_selection:
+				return
+
+			gs.println(DOMAIN, 'Requested New Name: {0}'.format(new_name))
+
+			offset =  '{0}:#{1}'.format(filename, region.begin())
+			command = ['gorename', '-offset', offset, '-to', new_name]
+
+			gs.println(DOMAIN, 'CMD: {0}'.format(' '.join(command)))
+
+			out = ""
+			try:
+				p = gs.popen(command, stderr=subprocess.STDOUT)
+				out = p.communicate()[0]
+				if p.returncode != 0:
+					raise OSError("GoRename failed")
+
+			except Exception as e:
+				msg = gs.tbck.format_exc()
+				if out:
+					msg = '{0}\n{1}'.format(msg, gs.ustr(out))
+				gs.show_output('GsGorename', msg, replace=False, merge_domain=False)
+
+		view.window().show_input_panel("New name:", current_selection, on_done, None, None)
+


### PR DESCRIPTION
Refs #114 

I've added a `GsGorename` command that uses `gorename` for either currently selection or the expanded word under the cursor. 

The check for a dirty file has been left disabled, as I am not sure if it should be prevented or not. Also, I have not yet given it a key mapping since all the good ones are taken :-)