### PR TITLE
Try to make go imports work as separated cmd.

### DIFF
--- a/GoSublime.sublime-commands
+++ b/GoSublime.sublime-commands
@@ -66,6 +66,10 @@
 		"command": "gs_fmt"
 	},
 	{
+		"caption": "GoSublime: Help you to make your imports clean",
+		"command": "gs_imports"
+	},	
+	{
 		"caption": "GoSublime: New Go File",
 		"command": "gs_new_go_file"
 	},

--- a/GoSublime.sublime-settings
+++ b/GoSublime.sublime-settings
@@ -45,6 +45,7 @@
 	// the command will be passed, to its stdin, the contents of the file
 	// it must output the new file contents
 	"fmt_cmd": [],
+	"goimports_cmd": ["goimports"],
 
 	// Whether or not gslint is enabled
 	"gslint_enabled": true,

--- a/gosubl/gs.py
+++ b/gosubl/gs.py
@@ -66,6 +66,7 @@ _default_settings = {
 	"fmt_tab_indent": True,
 	"fmt_tab_width": 8,
 	"fmt_cmd": [],
+	"goimports_cmd": ["goimports"],
 	"gslint_enabled": False,
 	"comp_lint_enabled": False,
 	"comp_lint_commands": [],

--- a/gosubl/mg9.py
+++ b/gosubl/mg9.py
@@ -320,6 +320,28 @@ def fmt(fn, src):
 	})
 	return res.get('src', ''), err
 
+def goimports(fn, src):
+	st = gs.settings_dict()
+	x = st.get('goimports_cmd')
+	if x:
+		res, err = bcall('sh', {
+			'Env': sh.env(),
+			'Cmd': {
+					'Name': x[0],
+					'Args': x[1:],
+					'Input': src or '',
+			},
+		})
+		return res.get('out', ''), (err or res.get('err', ''))
+
+	res, err = bcall('goimports', {
+		'Fn': fn or '',
+		'Src': src or '',
+		'TabIndent': st.get('fmt_tab_indent'),
+		'TabWidth': st.get('fmt_tab_width'),
+	})
+	return res.get('src', ''), err	
+
 def import_paths(fn, src, f):
 	tid = gs.begin(DOMAIN, 'Fetching import paths')
 	def cb(res, err):

--- a/src/gosubli.me/margo/m_goimports.go
+++ b/src/gosubli.me/margo/m_goimports.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+)
+
+type mGoImports struct {
+	Fn        string
+	Src       string
+	TabIndent bool
+	TabWidth  int
+}
+
+func (m *mGoImports) Call() (interface{}, string) {
+	res := M{}
+	fset, af, err := parseAstFile(m.Fn, m.Src, parser.ParseComments)
+	if err == nil {
+		ast.SortImports(fset, af)
+		res["src"], err = printSrc(fset, af, m.TabIndent, m.TabWidth)
+	}
+	return res, errStr(err)
+}
+
+func init() {
+	registry.Register("goimports", func(b *Broker) Caller {
+		return &mGoImports{
+			TabIndent: true,
+			TabWidth:  8,
+		}
+	})
+}


### PR DESCRIPTION
goimports is useful tools, but if it is triggered in on-save, it is a little bit annoying when coding golang.
So, I duplicate go_fmt with new go_imports, in order to give user a chance to set up below keybinding to run goimports mannually.

So, the better user experience is , we set go_fmt while on-save, and use go_imports when we need it.

```
{
        "keys": ["super+.", "super+f"],
        "command": "gs_imports",
        "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }]
    },
```