### PR TITLE
add argument templates for fmt_cmd to fix Goimport and vendoring

### DIFF
--- a/gosubl/mg9.py
+++ b/gosubl/mg9.py
@@ -302,11 +302,16 @@ def fmt(fn, src):
 	st = gs.settings_dict()
 	x = st.get('fmt_cmd')
 	if x:
+		import os.path
+		args = {
+			"filename": fn,
+			"filedir": os.path.dirname(fn),
+		}
 		res, err = bcall('sh', {
 			'Env': sh.env(),
 			'Cmd': {
 					'Name': x[0],
-					'Args': x[1:],
+					'Args': tuple([a % args for a in x[1:]]),
 					'Input': src or '',
 			},
 		})


### PR DESCRIPTION
According to https://github.com/golang/tools/commit/bf084ef7580ee99a5efa3086138c942aca4aefd4, goimports now need to be specified the directory of the source go file in order to properly infer the vendor imports.

This commit adds template capabilities to the `fmt_cmd` setting, adding `filename` and `filedir` variables. This won't break existing configurations.

The proper command for goimports now becomes:
```json
    "fmt_cmd": ["goimports", "-srcdir", "%(filedir)s"],
```