### PR TITLE
Add optional support for doc hints via "gogetdoc" tool

### DIFF
--- a/GoSublime.sublime-settings
+++ b/GoSublime.sublime-settings
@@ -319,5 +319,11 @@
 	// `GoSublime: HTML` files are html files with the template delimiters `{{` and `}}` tailored to
 	// Go templates (text/template, html/template)
 	// (`.gohtml` files are automatically set by the syntax definition)
-	"gohtml_extensions": [".html.go"]
+	"gohtml_extensions": [".html.go"],
+
+	// Choose between available tools for getting documentation hints. 
+	// `doc`: The custom internal solution provided by MarGo
+	// `gogetdoc`: Delegate to "gogetdoc" tool (Must be installed and available on PATH)
+	//
+	"doc_hint_tool": "doc"
 }

--- a/gosubl/gs.py
+++ b/gosubl/gs.py
@@ -97,6 +97,7 @@ _default_settings = {
 	"use_named_imports": False,
 	"installsuffix": "",
 	"ipc_timeout": 1,
+	"doc_hint_tool": "doc",
 }
 _settings = copy.copy(_default_settings)
 

--- a/gosubl/mg9.py
+++ b/gosubl/mg9.py
@@ -394,12 +394,19 @@ def imports(fn, src, toggle):
 	})
 
 def doc(fn, src, offset, f):
-	tid = gs.begin(DOMAIN, 'Fetching doc info')
+	docTool = gs.setting("doc_hint_tool", "").strip() or "doc"
+	avail = ("doc", "gogetdoc")
+	if docTool not in avail:
+		gs.println("doc_hint_tool '%s' not one of avail %r ; using 'doc'" \
+			% (docTool, avail))
+		docTool = "doc"
+
+	tid = gs.begin(DOMAIN, "Fetching doc info via '%s'" % docTool)
 	def cb(res, err):
 		gs.end(tid)
 		f(res, err)
 
-	acall('doc', {
+	acall(docTool, {
 		'fn': fn or '',
 		'src': src or '',
 		'offset': offset or 0,

--- a/gosubl/mg9.py
+++ b/gosubl/mg9.py
@@ -393,13 +393,16 @@ def imports(fn, src, toggle):
 		'tabWidth': gs.setting('fmt_tab_width'),
 	})
 
-def doc(fn, src, offset, f):
-	docTool = gs.setting("doc_hint_tool", "").strip() or "doc"
-	avail = ("doc", "gogetdoc")
-	if docTool not in avail:
-		gs.println("doc_hint_tool '%s' not one of avail %r ; using 'doc'" \
-			% (docTool, avail))
-		docTool = "doc"
+def doc(fn, src, offset, f, mode="goto"):
+	docTool = "doc"
+
+	if mode == "hint":
+		docTool = gs.setting("doc_hint_tool", "").strip() or "doc"
+		avail = ("doc", "gogetdoc")
+		if docTool not in avail:
+			gs.println("doc_hint_tool '%s' not one of avail %r ; using 'doc'" \
+				% (docTool, avail))
+			docTool = "doc"
 
 	tid = gs.begin(DOMAIN, "Fetching doc info via '%s'" % docTool)
 	def cb(res, err):

--- a/gsdoc.py
+++ b/gsdoc.py
@@ -67,7 +67,7 @@ class GsDocCommand(sublime_plugin.TextCommand):
 					doc = '\n\n\n'.join(s).strip()
 			self.show_output(doc or "// %s: no docs found" % DOMAIN)
 
-		mg9.doc(view.file_name(), src, pt, f)
+		mg9.doc(view.file_name(), src, pt, f, mode=mode)
 
 class GsBrowseDeclarationsCommand(sublime_plugin.WindowCommand):
 	def run(self, dir=''):


### PR DESCRIPTION
`gogetdoc` is a new tool which provides Editor-level support for looking up documentation in Go source files. 
- https://github.com/zmb3/gogetdoc
- https://zmb3.github.io/post/gogetdoc

This merge request adds _optional_ support for using `gogetdoc` when performing a Doc Hint action. The option can be enabled by setting `"doc_hint_tool": "gogetdoc"` in the GoSublime settings. 

I've added this through the same MarGo constructs that serve the internal documentation logic.
