### PR TITLE
Update GoSublime-Go.tmLanguage

### DIFF
--- a/syntax/GoSublime-Go.tmLanguage
+++ b/syntax/GoSublime-Go.tmLanguage
@@ -303,11 +303,12 @@
 				<dict>
 					<key>match</key>
 					<string>(?x)%
-                        (\d+\$)?                                    # field (argument #)
                         [#0\- +']*                                  # flags
+                        (\[\d+\])?                                  # field (argument #)
                         [,;:_]?                                     # separator character (AltiVec)
-                        ((-?\d+)|\*(-?\d+\$)?)?                     # minimum field width
-                        (\.((-?\d+)|\*(-?\d+\$)?)?)?                # precision
+                        ((-?\d+)|(\[\d+\])?\*)?                     # minimum field width
+                        (\.((-?\d+)|(\[\d+\])?\*)?)?                # precision
+                        (\[\d+\])?                                  # field (argument #), second optional placement
                         [diouxXDOUeEfFgGaAcCsSqpnvtTbyYhHmMzZ%]     # conversion type
                     </string>
 					<key>name</key>


### PR DESCRIPTION
I've fixed explicit argument indexes according to current spec https://golang.org/pkg/fmt/

Format is now highlighted when using indexes [n] in different cases.
Please, check the syntax highlighting for:
```
fmt.Printf("\nfoo %[1]s %[1]s", "bar")
fmt.Printf("\n%d %d %#[1]x %#x", 16, 17)
fmt.Printf("\n%#20[2]x %+#20[1]x", 16, 17)
fmt.Printf("\n%[3]*.[2]*[1]f", 12.0, 2, 6)
fmt.Printf("\n%6.2f", 12.0)
fmt.Printf("\n%*.*f", 6, 2, 12.0)
```

I wanted to know what should I do with GoSublime-Go.tmLanguage.json - this file seems to be redundant and autogenerated somehow. If it's not used by Sublime itself why do you need it?