### PR TITLE
better gspalette gslint report and also fix runtime error

### DIFF
--- a/gslint.py
+++ b/gslint.py
@@ -21,10 +21,11 @@ class FileRef(object):
 		self.reports = {}
 
 class Report(object):
-	def __init__(self, row, col, msg):
+	def __init__(self, row, col, msg, tye):
 		self.row = row
 		self.col = col
 		self.msg = msg
+		self.type = tye
 
 class GsLintThread(threading.Thread):
 	def __init__(self):
@@ -231,19 +232,29 @@ def do_comp_lint(dirname, fn):
 				gs.notice(DOMAIN, err)
 
 			out = out.replace('\r', '').replace('\n ', '\\n ').replace('\n\t', '\\n\t')
+			index = -1
 			for m in pat.findall(out):
+				index += 1
 				try:
 					row, col, msg = m
 					row = int(row)-1
 					col = int(col)-1 if col else 0
 					msg = msg.replace('\\n', '\n').strip()
+
+					msgArr = msg.split(":")
+					typ = msgArr[0]
+					msg = ':'.join(msgArr[1:])
+
 					if row >= 0 and msg:
-						msg = '%s: %s' % (cmd_domain, msg)
+						# hide cmd
+						# msg = '%s: %s' % (cmd_domain, msg)
 						if reports.get(row):
 							reports[row].msg = '%s\n%s' % (reports[row].msg, msg)
 							reports[row].col = max(reports[row].col, col)
 						else:
-							reports[row] = Report(row, col, msg)
+							reports[index] = Report(row, col, msg, typ)
+							
+						print("reports", reports)
 				except:
 					pass
 		except:

--- a/gslint.py
+++ b/gslint.py
@@ -253,8 +253,6 @@ def do_comp_lint(dirname, fn):
 							reports[row].col = max(reports[row].col, col)
 						else:
 							reports[index] = Report(row, col, msg, typ)
-							
-						print("reports", reports)
 				except:
 					pass
 		except:

--- a/gspalette.py
+++ b/gspalette.py
@@ -160,16 +160,7 @@ class GsPaletteCommand(sublime_plugin.WindowCommand):
 				r = reps[k]
 				loc = Loc(view.file_name(), r.row, r.col)
 				m = []
-				m.append("%sline %d:" % (indent, r.row+1))
-				lc = 0
-				for ln in r.msg.split('\n'):
-					if ln:
-						lc += 1
-						if len(ln) > 50:
-							m.append('\t%d: %s -' % (lc, ln[:50]))
-							m.append('\t  %s' % ln[50:])
-						else:
-							m.append('\t%d: %s' % (lc, ln))
+				m.append("%s#%d %s %s" % (indent, r.row+1, r.type.upper(), r.msg))
 
 				self.add_item(m, self.jump_to, (view, loc))
 		else:


### PR DESCRIPTION
* better gspalette by remove all the breaking lines and let sublime truncates them itself.
* by that we can fix ``win.show_quick_panel`` throw runtime error items has different lengths.

before
![screenshot from 2017-09-15 15-54-02](https://user-images.githubusercontent.com/1265628/30474804-0ba59412-9a2f-11e7-8434-898a062531a2.png)
after
![screenshot from 2017-09-15 15-52-44](https://user-images.githubusercontent.com/1265628/30474812-10bfc65c-9a2f-11e7-8bea-bf9b894ed9d7.png)
