### PR TITLE
Implemented an autocomplete_verbose setting prototype

### DIFF
--- a/GoSublime.sublime-settings
+++ b/GoSublime.sublime-settings
@@ -177,6 +177,14 @@
 	// note: this feature only comes into effect when autocomplete was triggered after a dot, e.g. `fmt.|`
 	"autocomplete_suggest_imports": false,
 
+	// whether or not function autocompletion suggestions will include the arguments and their types or
+	// just return types
+	// e.g. `Printf` autocompleted with verbose enabled will be
+	//     Printf	(format string, a ...interface{})	n int, err error ƒ
+	// while `Printf` autocompleted without verbose enabled will be
+	// 	   Printf	n int, err error ƒ
+	"autocomplete_verbose": false,
+
 	// whether or not to show function call tip in the status bar
 	// the same can be achieved ctrl+dot,ctrl+space using an output panel
 	"calltips": true,

--- a/gosubl/gs.py
+++ b/gosubl/gs.py
@@ -75,6 +75,7 @@ _default_settings = {
 	"autocomplete_tests": False,
 	"autocomplete_closures": False,
 	"autocomplete_filter_name": "",
+	"autocomplete_verbose": False,
 	"autocomplete_suggest_imports": False,
 	"on_save": [],
 	"shell": [],

--- a/gscomplete.py
+++ b/gscomplete.py
@@ -203,6 +203,9 @@ class GoSublime(sublime_plugin.EventListener):
 				ret = ret.strip('() ')
 
 				if is_func:
+					if gs.setting('autocomplete_verbose'):
+						ret = '(%s)\t%s' % (param_str(params), ret)
+
 					if func_name_only:
 						comps.append((
 							'%s\t%s %s' % (nm, ret, f_sfx),
@@ -234,6 +237,12 @@ class GoSublime(sublime_plugin.EventListener):
 	def typeclass_prefix(self, typeclass, typename):
 		return gs.NAME_PREFIXES.get(typename, gs.CLASS_PREFIXES.get(typeclass, ' '))
 
+
+def param_str(params):
+	ret = []
+	for p in params:
+		ret.append(' '.join(p))
+	return ', '.join(ret)
 
 def declex(s):
 	params = []


### PR DESCRIPTION
I basically just want a way to show me params and their types in the autocomplete text. This is incredibly useful when trying to find the right function to autocomplete with.

The flag might be better suited with a different name, and the python code may be subpar but this should provide a solid idea of what I'm trying to accomplish with this setting.