### PR TITLE
Add setting to control showing CHANGELOG on update

### DIFF
--- a/GoSublime.py
+++ b/GoSublime.py
@@ -94,7 +94,8 @@ def _plugin_loaded_async():
 			aso.set('version', about.VERSION)
 			aso.set('ann', about.ANN)
 			gs.save_aso()
-			gs.focus(gs.dist_path('CHANGELOG.md'))
+			if gs.setting('show_changelog_on_update'):
+				gs.focus(gs.dist_path('CHANGELOG.md'))
 
 	sublime.set_timeout(cb, 0)
 

--- a/GoSublime.sublime-settings
+++ b/GoSublime.sublime-settings
@@ -333,4 +333,7 @@
 	// so the env vars GS loads through your shell and project are available to other plugins
 	// e.g. "export_env_vars": ["PATH"]
 	"export_env_vars": [],
+
+	// Open CHANGELOG.md after updating GoSublime
+	"show_changelog_on_update": true,
 }

--- a/gosubl/gs.py
+++ b/gosubl/gs.py
@@ -99,6 +99,7 @@ _default_settings = {
 	"ipc_timeout": 1,
 	"export_env_vars": [],
 	"margo": {},
+	"show_changelog_on_update": True,
 }
 _settings = copy.copy(_default_settings)
 _mg_override_settings = {}


### PR DESCRIPTION
This adds a show_changelog_on_update setting to GoSublime. When the setting is disabled, GoSublime will not show the changelog when the plugin updates. By default the changelog will be shown as it is currently.

This might help with #702 and #325 bullet 4:
> After each update it's really not necessary to show the Changes list, unless there are major changes.

Previous opinion on that point was:

> Not going to change that. if it annoys you so much then file a feature request and i'll add an option to turn it off entirely.

So I hope this helps with that!

Thanks for your consideration and for developing a great plugin that I use daily.