### PR TITLE
Fix crash from deleting keys while iterating over dict in hud_panel()

### DIFF
--- a/gosubl/margo.py
+++ b/gosubl/margo.py
@@ -237,7 +237,7 @@ class MargoSingleton(object):
 
 			if len(m) > 1:
 				wids = [w.id() for w in sublime.windows()]
-				for id in m.keys():
+				for id in list(m.keys()):
 					if id not in wids:
 						del m[id]
 


### PR DESCRIPTION
Resolves #912 

The RuntimeError was caused by deleting keys from a dict while iterating over it. [That's not allowed](https://stackoverflow.com/a/5385075). The fix is to copy the dict keys to a list and iterate over that instead.