### PR TITLE
Add option to run `gofmt -s` as a Formatter

### DIFF
--- a/src/margo.sh/extension-example/extension-example.go
+++ b/src/margo.sh/extension-example/extension-example.go
@@ -74,6 +74,8 @@ func Margo(m mg.Args) {
 		// golang.GoFmt,
 		// or
 		// golang.GoImports,
+		// or (to run `gofmt -s` on a view)
+		// golang.GoFmtSimplify,
 
 		// Configure general auto-completion behaviour
 		&golang.MarGocodeCtl{

--- a/src/margo.sh/golang/gofmt.go
+++ b/src/margo.sh/golang/gofmt.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	GoFmt     mg.Reducer = mg.NewReducer(goFmt)
-	GoImports mg.Reducer = mg.NewReducer(goImports)
+	GoFmt         mg.Reducer = mg.NewReducer(goFmt)
+	GoImports     mg.Reducer = mg.NewReducer(goImports)
+	GoFmtSimplify mg.Reducer = mg.NewReducer(goFmtSimplify)
 
 	commonFmtLangs   = []mg.Lang{mg.Go}
 	commonFmtActions = []mg.Action{
@@ -45,6 +46,15 @@ func goImports(mx *mg.Ctx) *mg.State {
 	return disableGsFmt(mgformat.FmtCmd{
 		Name:    "goimports",
 		Args:    []string{"-srcdir", mx.View.Filename()},
+		Langs:   commonFmtLangs,
+		Actions: commonFmtActions,
+	}.Reduce(mx))
+}
+
+func goFmtSimplify(mx *mg.Ctx) *mg.State {
+	return disableGsFmt(mgformat.FmtCmd{
+		Name:    "gofmt",
+		Args:    []string{"-s"},
 		Langs:   commonFmtLangs,
 		Actions: commonFmtActions,
 	}.Reduce(mx))


### PR DESCRIPTION
In the past, I would set `fmt_cmd` to `["gofmt", "-s"]`. I recently realized that this is not what the builtin `golang.GoFmt` does as it does not also simplify the code. This patch adds this option as a builtin reducer.