### PR TITLE
Fix ANN 19.06.16.

### DIFF
--- a/gosubl/about.py
+++ b/gosubl/about.py
@@ -1,7 +1,7 @@
 import re
 import sublime
 
-TAG = '18.11.28-1'
+TAG = '19.06.16-1'
 ANN = 'a'+TAG
 VERSION = 'r'+TAG
 VERSION_PAT = re.compile(r'\d{2}[.]\d{2}[.]\d{2}-\d+', re.IGNORECASE)


### PR DESCRIPTION
I still keep getting the MOTD informing me about 19.06.16 even though I have it installed. I think this `about.py` modification was omitted.

It's a bit unclear if this will fully fix the issue, as I still get the MOTD even with this fix.