### PR TITLE
Add %w to syntax for Errorf wrapping verb.

### DIFF
--- a/syntax/GoSublime-Go-Recommended.sublime-syntax
+++ b/syntax/GoSublime-Go-Recommended.sublime-syntax
@@ -596,7 +596,7 @@ contexts:
             [,;:_]?                                     # separator character (AltiVec)
             ((-?\d+)|(\[\d+\])?\*)?                     # minimum field width
             (\.((-?\d+)|(\[\d+\])?\*)?)?                # precision
-            [diouxXDOUeEfFgGaAcCsSpqnvtTbyYhHmMzZ%]     # conversion type
+            [diouxwXDOUeEfFgGaAcCsSpqnvtTbyYhHmMzZ%]    # conversion type
       scope: constant.other.placeholder.go
     - match: "%"
       scope: invalid.illegal.placeholder.go


### PR DESCRIPTION
Since, [fmt.Errorf](https://godoc.org/fmt#Errorf) has `%w` verb, we should properly highlight it.

Also, for `go1.13` `go vet` doesn't recognize `Errorf` and allows the `%w` for `Sprintf` and similar methods. For more information see https://github.com/golang/go/issues/32070#issuecomment-557778497